### PR TITLE
Update avro.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/avro.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro.scala
@@ -39,7 +39,10 @@ package object avro extends DataSource {
    * Creates a new relation for data store in avro given a `path` as a parameter.
    */
   def createRelation(sqlContext: SQLContext, parameters: Map[String, String]) = {
-    AvroRelation(parameters("path"))(sqlContext)
+      parameters.get("path") match {
+      case Some(content) => AvroRelation(content)(sqlContext)
+      case None => sys.error(s"path is not set!")
+    }
   }
 
   /**


### PR DESCRIPTION
path may not set in parameters will lead to java.util.NoSuchElementException: key not found: path
