### PR TITLE
Add circle.yml file for configuring CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true)" test:compile assembly/assembly
+    - build/sbt test:compile
   cache_directories:
     - "~/.sbt"
 
@@ -12,7 +12,7 @@ test:
   override:
     - dev/lint-scala
     - dev/lint-java
-    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true)" sql/test
+    - build/sbt assembly/assembly sql/test
   # Copy test reports to Circle test reports dir
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/test-reports/

--- a/circle.yml
+++ b/circle.yml
@@ -4,13 +4,15 @@ machine:
 
 dependencies:
   override:
-    - build/sbt assembly  # since some tests might need the assembly JAR
+    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true) " assembly
+  cache_directories:
+    - "~/.sbt"
 
 test:
   override:
     - dev/lint-scala
     - dev/lint-java
-    - build/sbt sql/test
+    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true)" sql/test
   # Copy test reports to Circle test reports dir
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/test-reports/

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true)" assembly/assembly
+    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true)" test:compile assembly/assembly
   cache_directories:
     - "~/.sbt"
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  java:
+    version: openjdk7
+
+dependencies:
+  override:
+    - build/sbt assembly  # since some tests might need the assembly JAR
+
+test:
+  override:
+    - dev/lint-scala
+    - dev/lint-java
+    - build/sbt sql/test
+  # Copy test reports to Circle test reports dir
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/test-reports/
+    - mkdir -p $CIRCLE_TEST_REPORTS/logs/
+    - find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/test-reports/ \;
+    - find . -type f -regex ".*/target/unit-tests.*log" -exec cp {} $CIRCLE_TEST_REPORTS/logs/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,8 @@ test:
   override:
     - dev/lint-scala
     - dev/lint-java
-    - build/sbt assembly/assembly sql/test
+    - build/sbt assembly/assembly
+    - build/sbt sql/test
   # Copy test reports to Circle test reports dir
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/test-reports/

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true) " assembly
+    - build/sbt "set updateOptions := updateOptions.value.withCachedResolution(true)" assembly/assembly
   cache_directories:
     - "~/.sbt"
 


### PR DESCRIPTION
This patch adds a `circle.yml` file which configures CircleCI to run Scala/Java style checkers and the `sql` subproject's tests.
