### PR TITLE
Add more file format support for FileStreamSource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataStreamReader.scala
@@ -94,6 +94,7 @@ class DataStreamReader private[sql](sqlContext: SQLContext) extends Logging {
     val resolved = ResolvedDataSource.createSource(
       sqlContext,
       userSpecifiedSchema = userSpecifiedSchema,
+      partitionColumns = Array.empty[String],
       providerName = source,
       options = extraOptions.toMap)
     DataFrame(sqlContext, StreamingRelation(resolved))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
@@ -95,6 +95,7 @@ object ResolvedDataSource extends Logging {
   def createSource(
       sqlContext: SQLContext,
       userSpecifiedSchema: Option[StructType],
+      partitionColumns: Array[String],
       providerName: String,
       options: Map[String, String]): Source = {
     val provider = lookupDataSource(providerName).newInstance() match {
@@ -103,8 +104,20 @@ object ResolvedDataSource extends Logging {
         throw new UnsupportedOperationException(
           s"Data source $providerName does not support streamed reading")
     }
-
-    provider.createSource(sqlContext, options, userSpecifiedSchema)
+    userSpecifiedSchema match {
+      case Some(schema) => {
+        val maybePartitionsSchema = if (partitionColumns.isEmpty) {
+          None
+        } else {
+          Some(partitionColumnsSchema(
+            schema, partitionColumns, sqlContext.conf.caseSensitiveAnalysis))
+        }
+        val dataSchema =
+          StructType(schema.filterNot(f => partitionColumns.contains(f.name))).asNullable
+        provider.createSource(sqlContext, Some(dataSchema), maybePartitionsSchema, options)
+      }
+      case None => provider.createSource(sqlContext, None, None, options)
+    }
   }
 
   def createSink(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/DefaultSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/DefaultSource.scala
@@ -43,7 +43,6 @@ import org.apache.spark.util.SerializableConfiguration
 class DefaultSource
     extends HadoopFsRelationProvider
     with DataSourceRegister
-    with StreamSourceProvider
     with StreamSinkProvider {
 
   override def createRelation(
@@ -68,16 +67,6 @@ class DefaultSource
       throw new AnalysisException(
         s"Text data source supports only a string column, but you have ${tpe.simpleString}.")
     }
-  }
-
-  override def createSource(
-      sqlContext: SQLContext,
-      parameters: Map[String, String],
-      schema: Option[StructType]): Source = {
-    val path = parameters("path")
-    val metadataPath = parameters.getOrElse("metadataPath", s"$path/_metadata")
-
-    new FileStreamSource(sqlContext, metadataPath, path)
   }
 
   override def createSink(sqlContext: SQLContext, parameters: Map[String, String]): Sink = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -91,6 +91,13 @@ class StreamExecution(
     }
   }
   microBatchThread.setDaemon(true)
+  microBatchThread.setUncaughtExceptionHandler(
+    new UncaughtExceptionHandler {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = {
+        e.printStackTrace()
+        streamDeathCause = e
+      }
+    })
   microBatchThread.start()
 
   @volatile
@@ -98,12 +105,6 @@ class StreamExecution(
   @volatile
   private[sql] var streamDeathCause: Throwable = null
 
-  microBatchThread.setUncaughtExceptionHandler(
-    new UncaughtExceptionHandler {
-      override def uncaughtException(t: Thread, e: Throwable): Unit = {
-        streamDeathCause = e
-      }
-    })
 
   /**
    * Checks to see if any new data is present in any of the sources.  When new data is available,

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateMutableProjection
 import org.apache.spark.sql.execution.{FileRelation, RDDConversions}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.streaming.{Sink, Source}
+import org.apache.spark.sql.execution.streaming.{FileStreamSource, Sink, Source}
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -130,8 +130,9 @@ trait SchemaRelationProvider {
 trait StreamSourceProvider {
   def createSource(
       sqlContext: SQLContext,
-      parameters: Map[String, String],
-      schema: Option[StructType]): Source
+      partitionColumns: Option[StructType],
+      dataSchema: Option[StructType],
+      parameters: Map[String, String]): Source
 }
 
 /**
@@ -167,7 +168,7 @@ trait StreamSinkProvider {
  * @since 1.4.0
  */
 @Experimental
-trait HadoopFsRelationProvider {
+trait HadoopFsRelationProvider extends StreamSourceProvider {
   /**
    * Returns a new base relation with the given parameters, a user defined schema, and a list of
    * partition columns. Note: the parameters' keywords are case insensitive and this insensitivity
@@ -193,6 +194,28 @@ trait HadoopFsRelationProvider {
       throw new AnalysisException("Currently we don't support bucketing for this data source.")
     }
     createRelation(sqlContext, paths, dataSchema, partitionColumns, parameters)
+  }
+
+  override def createSource(
+    sqlContext: SQLContext,
+    partitionColumns: Option[StructType],
+    dataSchema: Option[StructType],
+    parameters: Map[String, String]): Source = {
+    val path = parameters("path")
+    val metadataPath = parameters.getOrElse("metadataPath", s"$path/_metadata")
+
+    def dataFrameBuilder(files: Array[String]): DataFrame = {
+      val relation = createRelation(
+        sqlContext,
+        files,
+        dataSchema,
+        partitionColumns,
+        bucketSpec = None,
+        parameters)
+      DataFrame(sqlContext, LogicalRelation(relation))
+    }
+
+    new FileStreamSource(sqlContext, metadataPath, path, dataSchema, dataFrameBuilder)
   }
 }
 


### PR DESCRIPTION
This PR adds more file format support for FileStreamSource. Because it reuses HadoopFsRelationProvider, all file formats in SQL will be supported. Also add a unit test to read from json files.
